### PR TITLE
feat: Possibility to ignore external updates.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -182,6 +182,10 @@ resource "google_artifact_registry_repository" "repo" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = var.ignore_changes
+  }
 }
 
 resource "google_artifact_registry_vpcsc_config" "repo_vpc_sc" {

--- a/variables.tf
+++ b/variables.tf
@@ -162,6 +162,13 @@ variable "cleanup_policies" {
   default     = {}
 }
 
+
+variable "ignore_changes" {
+  type        = list(string)
+  description = "List of resource attributes to ignore changes for"
+  default     = []
+}
+
 # VPC SC
 variable "enable_vpcsc_policy" {
   type        = bool


### PR DESCRIPTION
Some fields can be updated "outside of terraform" i.e. when pushing a docker image tag in a CICD pipeline. This backwards-compatible change allows to explicitly ignore external changes of certain fields (i.e. update_time)

fixes #47 