### PR TITLE
feat!: remove update_time output

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Functional examples are included in the
 | artifact\_id | an identifier for the resource |
 | artifact\_name | an identifier for the resource |
 | create\_time | The time when the repository was created. |
-| update\_time | The time when the repository was last updated. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -192,8 +192,6 @@ spec:
         description: an identifier for the resource
       - name: create_time
         description: The time when the repository was created.
-      - name: update_time
-        description: The time when the repository was last updated.
   requirements:
     roles:
       - level: Project

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,8 +28,3 @@ output "create_time" {
   description = "The time when the repository was created."
   value       = google_artifact_registry_repository.repo.create_time
 }
-
-output "update_time" {
-  description = "The time when the repository was last updated."
-  value       = google_artifact_registry_repository.repo.update_time
-}


### PR DESCRIPTION
Fix #57 by simply removing `update_time` output.
This is a breaking change.

# Steps to reproduce the drift

1. Simply create a registry with the exaple module
2. Push some image like `first-docker-repo/first` to the registry
3. Push another image like `first-docker-repo/second` to the same registry
4. Run terraform plan/apply shows a drift like following

```
$ terraform apply
module.artifact_registry.google_artifact_registry_repository.repo: Refreshing state... [id=projects/example/locations/asia-northeast1/repositories/first-docker-repo]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply" which may have
affected this plan:

  # module.artifact_registry.google_artifact_registry_repository.repo has changed
  ~ resource "google_artifact_registry_repository" "repo" {
        id                     = "projects/example/locations/asia-northeast1/repositories/first-docker-repo"
        name                   = "first-docker-repo"
      ~ update_time            = "2025-12-24T05:44:14.523490Z" -> "2025-12-24T05:46:36.186400Z"
        # (13 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using
ignore_changes, the following plan may include actions to undo or respond to these changes.
```