### PR TITLE
fix!: continue PR #85 – enforce vulnerability scanning block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ credentials.json
 
 # tf lock file
 .terraform.lock.hcl
+.terraform.lock

--- a/docs/upgrading_to_v0.8.3.md
+++ b/docs/upgrading_to_v0.8.3.md
@@ -1,0 +1,31 @@
+## Upgrade to v0.8.3
+
+### ⚠️ Breaking change: output variable renames
+
+The following output variables have been renamed:
+
+| Old name | New name |
+|--------|---------|
+| `artifact_id` | `repository_id` |
+| `repository_name` | `repository_name` |
+
+#### Why
+The new names better reflect the resource structure and improve consistency.
+
+#### Migration
+Update all references to the renamed outputs in your Terraform configuration:
+
+```hcl
+# Before
+module.repo.artifact_id
+module.repo.repository_name
+
+# After
+module.repo.repository_id
+module.repo.repository_name
+
+# Then run
+
+terraform init -upgrade
+terraform plan
+```

--- a/versions.tf
+++ b/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.26.0, < 8"
+      version = ">= 6.15.0, < 8"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.26.0, < 8"
+      version = ">= 6.15.0, < 8"
     }
   }
 


### PR DESCRIPTION
### Context
This PR continues the work from #85 and addresses all requested changes.

### Changes
- Increase minimal version of google provider
- add terraform lock file in gitignore
- Add upgrade guide

### ⚠️ Breaking Change
- Users must update their Terraform configuration to include the vulnerability scanning block.
- See the upgrade guide for migration instructions.

